### PR TITLE
Add brief explanation where to find crash dumps to manual.

### DIFF
--- a/crash_dumps/manual.md
+++ b/crash_dumps/manual.md
@@ -1,0 +1,16 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+
+This file is part of Ramses Composer
+(see https://github.com/GENIVI/ramses-composer-docs).
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+# Crash dumps
+
+Ramses Composer might crash during use. If it does, in nearly all cases it will generate a "dump file" called "RamsesComposer_X.Y.Z_DATE_TIME.dmp" next to the RamsesComposer.exe.
+
+The dump file records the exact location of the crash in the code, and hence it is very useful when trying to track down crashes which are hard to reproduce. 
+
+Please attach the crash dumps to bug reports about crashes if possible.

--- a/manual.md
+++ b/manual.md
@@ -52,3 +52,5 @@ The authoring tool for the RAMSES graphics toolchain.
 [Using the Log Output Console](using_log_console/manual.md)
 
 [Common Issues](common_issues/manual.md)
+
+[Crash dumps](crash_dumps/manual.md)


### PR DESCRIPTION
Added the section about the RaCo crash dumps (as discussed in mail).